### PR TITLE
Add temperature in popup

### DIFF
--- a/PROJECT_SUMMARY.md
+++ b/PROJECT_SUMMARY.md
@@ -44,7 +44,7 @@ Local Windows service + Svelte web UI to monitor telemetry and control core plat
   - Renders panels: Telemetry, Power, Fan Control; layout adapts to fan mode
   - Integrates `FanControl.svelte` for Auto/Manual/Curve config
 - API client: `web/src/api/*` generated from OpenAPI (`scripts/gen-api.mjs`)
-- Components: `web/src/components/*` (`DeviceHeader.svelte`, `Panel.svelte`, `FanControl.svelte`)
+- Components: `web/src/components/*` (`DeviceHeader.svelte`, `Panel.svelte`, `FanControl.svelte`, `Telemetry.svelte`)
   - `SettingsModal.svelte`: adds Updates section to check/apply service updates
 - Shared utilities: `web/src/lib/*`
 - Frontend API usage guideline (do not bypass):

--- a/service/src/types.rs
+++ b/service/src/types.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use poem_openapi::{Enum, Object};
 use serde::{Deserialize, Serialize};
 
@@ -8,9 +10,19 @@ pub struct Config {
     pub fan: FanControlConfig,
     #[serde(default)]
     pub updates: UpdatesConfig,
+    #[serde(default = "default_high_temperature_threshold")]
+    pub high_temperature_threshold: u32
 }
 
-impl Default for Config { fn default() -> Self { Self { fan: FanControlConfig::default(), updates: UpdatesConfig::default() } } }
+impl Default for Config { 
+    fn default() -> Self { 
+        Self { 
+            fan: FanControlConfig::default(), 
+            updates: UpdatesConfig::default(),
+            high_temperature_threshold: default_high_temperature_threshold(),
+        } 
+    } 
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Enum, Default)]
 #[serde(rename_all = "lowercase")]
@@ -55,6 +67,7 @@ fn default_points() -> Vec<[u32; 2]> { vec![[40, 0], [60, 40], [75, 80], [85, 10
 fn default_poll_ms() -> u64 { 2000 }
 fn default_hysteresis_c() -> u32 { 2 }
 fn default_rate_limit_pct_per_step() -> u32 { 100 }
+fn default_high_temperature_threshold() -> u32 { 100 }
 
 // API envelope types
 #[derive(Serialize, Object)]
@@ -73,6 +86,12 @@ pub struct ConfigEnvelope {
 #[derive(Serialize, Object)]
 pub struct UpdateResult {
     pub ok: bool,
+}
+
+#[derive(Serialize, Object)]
+pub struct TemperaturesResult {
+    pub ok: bool,
+    pub temps: HashMap<String, String>
 }
 
 #[derive(Serialize, Object)]

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -9,6 +9,7 @@
   import { OpenAPI } from "./api";
   import VersionMismatchModal from "./components/VersionMismatchModal.svelte";
   import { gtSemver } from "./lib/semver";
+  import Telemetry from "./components/Telemetry.svelte";
 
   let healthy: boolean = false;
   let cliPresent: boolean = true;
@@ -97,17 +98,7 @@
           class={"col-span-12 " + panelGridClasses(pid, healthy, fanMode)}
         >
           {#if pid === "telemetry"}
-            <Panel title="Telemetry (Coming soon)" expandable={healthy}>
-              <div class="text-sm opacity-80">
-                Live temps and fan RPM read locally via the service. Nothing
-                leaves your machine.
-              </div>
-              <ul class="list-disc list-inside text-sm opacity-80 space-y-1">
-                <li>Temps and fan RPM</li>
-                <li>AC/battery status and basic battery info</li>
-                <li>Time‑series charts & live updates</li>
-              </ul>
-            </Panel>
+            <Telemetry bind:healthy />
           {:else if pid === "power"}
             <Panel title="Power (Coming soon)" expandable={healthy}>
               <div class="text-sm opacity-80">

--- a/web/src/components/Panel.svelte
+++ b/web/src/components/Panel.svelte
@@ -64,6 +64,7 @@
           </button>
         </div>
         <slot />
+        <slot name="expended-only" />
       </div>
     </div>
     <button class="modal-backdrop" aria-label="Close overlay" on:click={() => (isExpanded = false)}></button>

--- a/web/src/components/Telemetry.svelte
+++ b/web/src/components/Telemetry.svelte
@@ -1,0 +1,70 @@
+<script lang="ts">
+    import { onDestroy, onMount } from "svelte";
+    import Panel from "./Panel.svelte";
+    import { DefaultService } from "../api";
+
+    export let healthy: boolean;
+    
+    let pid: NodeJS.Timeout | undefined = undefined;
+    let termals: Record<string, string> = {};
+    let high_temp_threshold: number = 100;
+
+    async function refresh() {
+        let resp = await DefaultService.getThermal();
+        if (resp.ok) {
+            termals = resp.temps
+        }
+        return "";
+    }
+
+    onMount(async () => {
+        let resp = await DefaultService.getConfig();
+        if (resp.ok) {
+            high_temp_threshold = resp.config.high_temperature_threshold
+        }
+        pid = setInterval(refresh, 1000);
+    });
+    onDestroy(() => {
+        if (pid) clearInterval(pid);
+    });
+</script>
+
+<Panel title="Telemetry" expandable={healthy}>
+    <div class="text-sm opacity-80">
+        Live temps and fan RPM read locally via the service. Nothing leaves your
+        machine.
+    </div>
+    <ul class="list-disc list-inside text-sm opacity-80 space-y-1">
+        <li>Temps and fan RPM</li>
+        <li>AC/battery status and basic battery info</li>
+        <li>Time‑series charts & live updates</li>
+    </ul>
+    <div slot="expended-only" class="flex flex-col">
+        {#await refresh()}
+            <div>Loading...</div>
+        {:then ignored}
+            <table>
+                <thead>
+                    <th class="text-left">Sensor</th>
+                    <th class="text-right">Temperature</th>
+                </thead>
+                <tbody>
+                    {#each Object.keys(termals) as sensor}
+                        <tr>
+                            <td class="text-left text-sm opacity-80">{sensor}</td>
+                            {#if parseInt(termals[sensor]) > high_temp_threshold}
+                                <td class="text-right text-sm text-red-500 bold">
+                                    {termals[sensor] ?? "N/A"}
+                                </td>
+                            {:else}
+                                <td class="text-right text-sm opacity-80">{termals[sensor] ?? "N/A"}</td>
+                            {/if}
+                        </tr>
+                    {/each}
+                </tbody>
+            </table>
+        {:catch error}
+            <div>Error from service: {error}</div>
+        {/await}
+    </div>
+</Panel>


### PR DESCRIPTION
## Summary

- Added a table of temperatures to the popup.
- Added a way to put content only in popup.

## Checklist

- [x] Updated `framework-control/PROJECT_SUMMARY.md` to reflect new/changed:
  - Endpoints in `service/src/routes.rs` (@routes.rs)
  - App wiring or startup in `service/src/main.rs` (@main.rs)
  - UI components/panels in `web/src` (e.g., @App.svelte)
  - Config/env or background tasks
- [x] Built backend (`cargo build`) and frontend (`npm run build`) where applicable
- [x] Tested locally (UI + API)

## Notes

The table is in the popup since, in the main page, it extended everything and I didn't know how you'd like the modification to finalized style to be. I'm not that good at UX so I'm happy changing anything visual.

It is my first PR in open-source, any feedback would be lovely!

Here's how it looks like:
<img width="1184" height="773" alt="Screenshot 2025-10-06 172718" src="https://github.com/user-attachments/assets/877e917c-6f1e-4244-b1c3-a53efcadce1f" />
<img width="1222" height="805" alt="Screenshot 2025-10-06 182458" src="https://github.com/user-attachments/assets/e416bd03-bc69-4e9a-9389-59da2b6332f1" />




