### PR TITLE
service: make framework_tool health checks lazy and back off installs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+- Service: Removed the periodic `framework_tool --versions` liveness check that spawned a process every 5 seconds even when no UI was connected (#34). Tool health is now validated on demand — a failing `framework_tool` call flags it and the background resolver confirms once with `--versions` before clearing it — so no health-check processes are spawned while the tool is working.
+- Service: The background resolver now uses exponential backoff (5s up to a 5min cap) when `framework_tool` is missing, instead of retrying installation every 5 seconds indefinitely.
+
 ## 0.5.2 - 2026-07-15
 
 - **Nix support**: Added `flake.nix`, `nix/package.nix`, and `nix/module.nix` for building and running as a NixOS service. Enables `services.framework-control.enable = true` in NixOS configurations. Work in progress toward a nixpkgs submission.

--- a/service/src/cli/framework_tool.rs
+++ b/service/src/cli/framework_tool.rs
@@ -2,7 +2,16 @@ use super::framework_tool_parser::{
     parse_power, parse_thermal, parse_versions, PowerBatteryInfo, ThermalParsed, VersionsParsed,
 };
 use crate::utils::{download as dl, github as gh, global_cache};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
+
+/// True after a framework_tool process fails (spawn/exit/timeout), cleared on
+/// success, so the resolver re-validates only when a real call hit trouble.
+static TOOL_SUSPECT: AtomicBool = AtomicBool::new(false);
+
+pub fn tool_suspect() -> bool {
+    TOOL_SUSPECT.load(Ordering::Relaxed)
+}
 
 #[cfg(target_os = "windows")]
 use crate::utils::wget as wg;
@@ -114,25 +123,30 @@ impl FrameworkTool {
 
     async fn run(&self, args: &[&str]) -> Result<String, String> {
         use tokio::time::{timeout, Duration};
-        let child = Command::new(&self.path)
-            .args(args)
-            .stdout(std::process::Stdio::piped())
-            .stderr(std::process::Stdio::piped())
-            .spawn()
-            .map_err(|e| format!("spawn failed: {e}"))?;
-        let output = timeout(Duration::from_secs(60), child.wait_with_output())
-            .await
-            .map_err(|_| "framework_tool timed out".to_string())
-            .and_then(|res| res.map_err(|e| format!("wait failed: {e}")))?;
-        if output.status.success() {
-            Ok(String::from_utf8_lossy(&output.stdout).to_string())
-        } else {
-            Err(format!(
-                "exit {}: {}",
-                output.status,
-                String::from_utf8_lossy(&output.stderr)
-            ))
+        let result = async {
+            let child = Command::new(&self.path)
+                .args(args)
+                .stdout(std::process::Stdio::piped())
+                .stderr(std::process::Stdio::piped())
+                .spawn()
+                .map_err(|e| format!("spawn failed: {e}"))?;
+            let output = timeout(Duration::from_secs(60), child.wait_with_output())
+                .await
+                .map_err(|_| "framework_tool timed out".to_string())
+                .and_then(|res| res.map_err(|e| format!("wait failed: {e}")))?;
+            if output.status.success() {
+                Ok(String::from_utf8_lossy(&output.stdout).to_string())
+            } else {
+                Err(format!(
+                    "exit {}: {}",
+                    output.status,
+                    String::from_utf8_lossy(&output.stderr)
+                ))
+            }
         }
+        .await;
+        TOOL_SUSPECT.store(result.is_err(), Ordering::Relaxed);
+        result
     }
 }
 

--- a/service/src/state.rs
+++ b/service/src/state.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use crate::cli::framework_tool::resolve_or_install;
+use crate::cli::framework_tool::{resolve_or_install, tool_suspect};
 use crate::cli::FrameworkTool;
 use crate::types::Config;
 
@@ -101,27 +101,41 @@ impl AppState {
     fn spawn_framework_tool_resolver(ft_lock: Arc<tokio::sync::RwLock<Option<FrameworkTool>>>) {
         tokio::spawn(async move {
             use tokio::time::{sleep, Duration};
+            // Steady cadence while present; exponential backoff while absent.
+            const BASE: Duration = Duration::from_secs(5);
+            const MAX_BACKOFF: Duration = Duration::from_secs(300);
+            let mut backoff = BASE;
+
             loop {
                 let current = { ft_lock.read().await.clone() };
-                match current {
+                let wait = match current {
+                    // Confirm before clearing so a transient failure doesn't drop a tool that still works.
                     Some(cli) => {
-                        // Validate liveness; if not runnable, clear state (no auto-install here)
-                        if cli.versions().await.is_err() {
+                        if tool_suspect() && cli.versions().await.is_err() {
                             let mut w = ft_lock.write().await;
                             *w = None;
-                            tracing::warn!("state: framework_tool became unavailable; clearing from state");
+                            tracing::warn!("state: framework_tool no longer responding; cleared from state");
                         }
+                        backoff = BASE;
+                        BASE
                     }
-                    None => {
-                        // Try resolving or installing if not present
-                        if let Ok(cli) = resolve_or_install().await {
+                    None => match resolve_or_install().await {
+                        Ok(cli) => {
                             let mut w = ft_lock.write().await;
                             *w = Some(cli);
                             tracing::info!("state: framework_tool is now available");
+                            backoff = BASE;
+                            BASE
                         }
-                    }
-                }
-                sleep(Duration::from_secs(5)).await;
+                        Err(_) => {
+                            let this_wait = backoff;
+                            backoff = (backoff * 2).min(MAX_BACKOFF);
+                            tracing::debug!("state: framework_tool unavailable; next attempt in {:?}", this_wait);
+                            this_wait
+                        }
+                    },
+                };
+                sleep(wait).await;
             }
         });
     }


### PR DESCRIPTION
Drop the unconditional 5s `--versions` liveness probe that ran even with no UI connected (#34). Tool health is now validated on demand: run() flags failures via a TOOL_SUSPECT signal, and the resolver confirms once with --versions before clearing state. Add exponential backoff (5s→5min) to the missing-tool resolve/install retry instead of looping every 5s.

Update CHANGELOG and PROJECT_SUMMARY.

## Summary

Describe the change and its impact.

## Checklist

- [ ] Updated `framework-control/PROJECT_SUMMARY.md` to reflect new/changed:
  - Endpoints in `service/src/routes.rs` (@routes.rs)
  - App wiring or startup in `service/src/main.rs` (@main.rs)
  - UI components/panels in `web/src` (e.g., @App.svelte)
  - Config/env or background tasks
- [ ] Built backend (`cargo build`) and frontend (`npm run build`) where applicable
- [ ] Tested locally (UI + API)

## Notes

Add migration notes, screenshots, or follow-ups.


